### PR TITLE
feat: `fr`, `ca`, `cs` locales support

### DIFF
--- a/.changeset/early-fireants-share.md
+++ b/.changeset/early-fireants-share.md
@@ -1,0 +1,5 @@
+---
+"@replexica/spec": minor
+---
+
+enable french, catalan in source/target mode, and czech in source-only mode

--- a/packages/spec/src/locales.ts
+++ b/packages/spec/src/locales.ts
@@ -1,13 +1,23 @@
 import Z from 'zod';
 
-const coreLocales = ['en', 'es'] as const;
+const coreLocales = [
+  'en', // English
+  'es', // Spanish
+  'fr', // French
+  'ca', // Catalan
+] as const;
 
 // Source
-export const sourceLocales = [...coreLocales] as const;
+export const sourceLocales = [
+  ...coreLocales,
+  'cs', // Czech
+] as const;
 
 export const sourceLocaleSchema = Z.enum(sourceLocales);
 
 // Target
-export const targetLocales = [...coreLocales] as const;
+export const targetLocales = [
+  ...coreLocales,
+] as const;
 
 export const targetLocaleSchema = Z.enum(targetLocales);

--- a/packages/spec/src/locales.ts
+++ b/packages/spec/src/locales.ts
@@ -1,11 +1,13 @@
 import Z from 'zod';
 
+const coreLocales = ['en', 'es'] as const;
+
 // Source
-export const sourceLocales = ['en'] as const;
+export const sourceLocales = [...coreLocales] as const;
 
 export const sourceLocaleSchema = Z.enum(sourceLocales);
 
 // Target
-export const targetLocales = ['es'] as const;
+export const targetLocales = [...coreLocales] as const;
 
 export const targetLocaleSchema = Z.enum(targetLocales);


### PR DESCRIPTION
Enable `fr`, `ca` in source+target modes, `cs` (Czech) in source-only mode.

Resolves #63 