### PR TITLE
fix(cli): Preserve order of JSON keys during localization

### DIFF
--- a/.changeset/tame-timers-jam.md
+++ b/.changeset/tame-timers-jam.md
@@ -1,0 +1,6 @@
+---
+"@replexica/cli": patch
+"replexica": patch
+---
+
+Preserve order of keys in JSONs

--- a/packages/cli/src/cli/i18n.ts
+++ b/packages/cli/src/cli/i18n.ts
@@ -175,7 +175,10 @@ export default new Command()
           }
           // Merge the processed payload and the original target payload into a single entity
           const newTargetPayload = _.omit(
-            _.merge(targetPayload, processedPayload),
+            // Here we init an empty object, and first merge source payload and then target payload into it,
+            // so when the target/processed payload objects take precedence over the source payload keys/values,
+            // the order/position of the keys in the final object matches the order of the keys in the source payload
+            _.merge({}, sourcePayload, targetPayload, processedPayload),
             Object.keys(deletedPayload),
           );
           // Save the new target payload


### PR DESCRIPTION
Resolves #150 

--

cc @quentin-decre 