### PR TITLE
feat(spec): exclusion patterns

### DIFF
--- a/.changeset/honest-keys-deliver.md
+++ b/.changeset/honest-keys-deliver.md
@@ -1,0 +1,9 @@
+---
+"@replexica/compiler": minor
+"@replexica/react": minor
+"@replexica/spec": minor
+"@replexica/cli": minor
+"replexica": minor
+---
+
+Configuration spec v1.1: Improved bucket config structure, to support exclusion patterns

--- a/package/demo/markdown-multi/en/another-blog-post.md
+++ b/package/demo/markdown-multi/en/another-blog-post.md
@@ -1,1 +1,3 @@
-# Hola mundo
+# Hello world 12
+
+This is another blog post.

--- a/package/demo/markdown-multi/en/blog-post.md
+++ b/package/demo/markdown-multi/en/blog-post.md
@@ -1,5 +1,5 @@
 ---
-title: stringyfy
+title: stringyfy 1.0.1
 description: >-
   Una sencilla biblioteca de npm que proporciona un conjunto de funciones
   utilitarias para manipular y transformar cadenas en JavaScript.

--- a/package/demo/markdown-multi/en/ignored-blog-post.md
+++ b/package/demo/markdown-multi/en/ignored-blog-post.md
@@ -1,0 +1,3 @@
+# Ingored blog post
+
+This is a blog post that should be ignored during Replexica i18n processing.

--- a/package/demo/markdown-multi/es/another-blog-post.md
+++ b/package/demo/markdown-multi/es/another-blog-post.md
@@ -1,1 +1,3 @@
-# Hola mundo
+# Hola mundo 12
+
+Este es otro artículo del blog.

--- a/package/demo/markdown-multi/es/blog-post.md
+++ b/package/demo/markdown-multi/es/blog-post.md
@@ -1,5 +1,5 @@
 ---
-title: stringyfy
+title: stringyfy 1.0.1
 description: Una sencilla biblioteca de npm que proporciona un conjunto de funciones utilitarias para manipular y transformar cadenas en JavaScript.
 meta:
   - name: keywords

--- a/package/i18n.json
+++ b/package/i18n.json
@@ -1,4 +1,5 @@
 {
+  "version": 1.1,
   "locale": {
     "source": "en",
     "targets": [
@@ -6,12 +7,39 @@
     ]
   },
   "buckets": {
-    "demo/markdown-multi/[locale]/*.md": "markdown",
-    "demo/markdown/[locale].md": "markdown",
-    "demo/xcode/Localizable.xcstrings": "xcode",
-    "demo/android/[locale].xml": "android",
-    "demo/json/[locale].json": "json",
-    "demo/yaml/[locale].yml": "yaml",
-    "demo/yaml-root-key/[locale].yml": "yaml-root-key"
+    "markdown": {
+      "include": [
+        "demo/markdown-multi/[locale]/*.md",
+        "demo/markdown/[locale].md"
+      ],
+      "exclude": [
+        "demo/markdown-multi/[locale]/ignored-blog-post.md"
+      ]
+    },
+    "xcode": {
+      "include": [
+        "demo/xcode/Localizable.xcstrings"
+      ]
+    },
+    "android": {
+      "include": [
+        "demo/android/[locale].xml"
+      ]
+    },
+    "json": {
+      "include": [
+        "demo/json/[locale].json"
+      ]
+    },
+    "yaml": {
+      "include": [
+        "demo/yaml/[locale].yml"
+      ]
+    },
+    "yaml-root-key": {
+      "include": [
+        "demo/yaml-root-key/[locale].yml"
+      ]
+    }
   }
 }

--- a/package/i18n.lock
+++ b/package/i18n.lock
@@ -23,7 +23,7 @@ checksums:
     markdown-line-19: 573fef58ee9dfcb675a4d7065246a62d
     markdown-line-20: b3ae28fa7265f69ffbe8715674ced970
     markdown-line-21: 9aa9e2407df4773224e6facfa03778c6
-    frontmatter-attribute-title: 7603ae14015f4efc61d5720a45bcb16c
+    frontmatter-attribute-title: 8be4dd42fdbd3918a9c7a8b4b612379f
     frontmatter-attribute-description: 4eae601f40ada021777cb6feed74693d
     frontmatter-attribute-meta/0/name: c08d869b04124e62f7eb14e1e04788b9
     frontmatter-attribute-meta/0/content: 3c8256186fc62c8b0059b9f2d53992c8
@@ -36,7 +36,8 @@ checksums:
     frontmatter-attribute-sidebar: 1d41ad90ddfd2afba95b5a20b4f2d5da
     frontmatter-attribute-category: 7490d4f6c5aebce212e93d2842031ceb
   a1e485ffd9a36a6c6320101a5afd2471:
-    markdown-line-0: 82d9f0dc93ba52a49125ecf62159d0c9
+    markdown-line-0: 856bcaa0a60d9898303f8e165da774a3
+    markdown-line-1: f25ee9ff1279555b67e23c9407453aa1
   8fc5c7fe5cca683299c04ddf643d4475:
     markdown-line-0: 055771580c400345d100ceff7b2e4a58
     markdown-line-1: 6c1bd156be5138076bd8ba53f819c404

--- a/packages/cli/src/cli/i18n.ts
+++ b/packages/cli/src/cli/i18n.ts
@@ -4,7 +4,7 @@ import { loadConfig } from './../workers/config';
 import { loadSettings } from './../workers/settings';
 import Ora from 'ora';
 import _ from 'lodash';
-import { targetLocaleSchema } from '@replexica/spec';
+import { bucketTypeSchema, targetLocaleSchema } from '@replexica/spec';
 import { createLockfileProcessor } from './../workers/lockfile';
 import { createAuthenticator } from './../workers/auth';
 import { ReplexicaEngine } from '@replexica/sdk';
@@ -89,17 +89,21 @@ export default new Command()
       const targetedBuckets = flags.bucket ? { [flags.bucket]: i18nConfig.buckets[flags.bucket] } : i18nConfig.buckets;
 
       // Expand the placeholdered globs into actual (placeholdered) paths
-      const targetedBucketsTuples = Object.entries(targetedBuckets);
-      const placeholderedPathsTuples: [string, typeof targetedBuckets[keyof typeof targetedBuckets]][] = [];
-      for (const [placeholderedGlob, bucketType] of targetedBucketsTuples) {
-        const placeholderedPaths = expandPlaceholderedGlob(placeholderedGlob, i18nConfig.locale.source);
-        for (const placeholderedPath of placeholderedPaths) {
-          placeholderedPathsTuples.push([placeholderedPath, bucketType]);
+      const placeholderedPathsTuples: [Z.infer<typeof bucketTypeSchema>, string][] = [];
+      for (const [bucketType, bucketTypeParams] of Object.entries(targetedBuckets)) {
+        for (const placeholderedGlob of bucketTypeParams.paths) {
+          const placeholderedPaths = expandPlaceholderedGlob(placeholderedGlob, i18nConfig.locale.source);
+          for (const placeholderedPath of placeholderedPaths) {
+            placeholderedPathsTuples.push([
+              bucketType as Z.infer<typeof bucketTypeSchema>,
+              placeholderedPath
+            ]);
+          }
         }
       }
 
       const lockfileProcessor = createLockfileProcessor();
-      for (const [placeholderedPath, bucketType] of placeholderedPathsTuples) {
+      for (const [bucketType, placeholderedPath] of placeholderedPathsTuples) {
         console.log('');
         const bucketOra = Ora({});
         bucketOra.info(`Processing ${placeholderedPath}`);
@@ -207,7 +211,7 @@ export default new Command()
 async function loadFlags(options: any) {
   return Z.object({
     locale: targetLocaleSchema.optional(),
-    bucket: Z.string().optional(),
+    bucket: bucketTypeSchema.optional(),
     force: Z.boolean().optional(),
     frozen: Z.boolean().optional(),
   }).parse(options);

--- a/packages/cli/src/cli/i18n.ts
+++ b/packages/cli/src/cli/i18n.ts
@@ -198,7 +198,7 @@ export default new Command()
       // if explicit bucket flag is provided, do not clean up the lockfile,
       // because we might have skipped some buckets, and we don't want to lose the checksums
       if (!flags.bucket) {
-        const placeholderedPaths = placeholderedPathsTuples.map(([placeholderedPath]) => placeholderedPath);
+        const placeholderedPaths = placeholderedPathsTuples.map(([,placeholderedPath]) => placeholderedPath);
         await lockfileProcessor.cleanupCheksums(placeholderedPaths);
       }
 

--- a/packages/cli/src/cli/init.ts
+++ b/packages/cli/src/cli/init.ts
@@ -10,7 +10,7 @@ export default new Command()
   .action(async (options) => {
     const spinner = Ora().start('Initializing Replexica project');
 
-    let config = await loadConfig();
+    let config = await loadConfig(false);
     if (config) {
       spinner.fail('Replexica project already initialized');
       return process.exit(1);

--- a/packages/cli/src/workers/config.ts
+++ b/packages/cli/src/workers/config.ts
@@ -1,9 +1,9 @@
 import Z from 'zod';
 import fs from 'fs';
 import path from 'path';
-import { configFileSchema } from '@replexica/spec';
+import { I18nConfig, parseI18nConfig } from '@replexica/spec';
 
-export async function loadConfig(): Promise<Z.infer<typeof configFileSchema> | null> {
+export async function loadConfig(resave = true): Promise<I18nConfig | null> {
   const configFilePath = _getConfigFilePath();
 
   const configFileExists = await fs.existsSync(configFilePath);
@@ -11,12 +11,18 @@ export async function loadConfig(): Promise<Z.infer<typeof configFileSchema> | n
 
   const fileContents = fs.readFileSync(configFilePath, "utf8");
   const rawConfig = JSON.parse(fileContents);
-  const config = configFileSchema.parse(rawConfig);
 
-  return config;
+  const result = parseI18nConfig(rawConfig);
+
+  if (resave) {
+    // Ensure the config is saved with the latest version / schema
+    await saveConfig(result);
+  }
+
+  return result;
 }
 
-export async function saveConfig(config: Z.infer<typeof configFileSchema>) {
+export async function saveConfig(config: I18nConfig) {
   const configFilePath = _getConfigFilePath();
 
   const serialized = JSON.stringify(config, null, 2);

--- a/packages/compiler/src/_utils.ts
+++ b/packages/compiler/src/_utils.ts
@@ -1,4 +1,5 @@
-import { CompilerConfig, I18nConfig, loadI18nConfig } from "./config";
+import { I18nConfig } from "@replexica/spec";
+import { CompilerConfig, loadI18nConfig } from "./config";
 
 export type SubcompilerFactory<R> = {
   (compilerConfig: CompilerConfig, i18nConfig: I18nConfig): R;

--- a/packages/compiler/src/config.ts
+++ b/packages/compiler/src/config.ts
@@ -1,7 +1,7 @@
 import Z from 'zod';
 import path from 'path';
 import fs from 'fs';
-import { configFileSchema } from '@replexica/spec';
+import { parseI18nConfig, I18nConfig } from '@replexica/spec';
 
 const compilerConfigSchema = Z.object({
   sourceRoot: Z.string().optional().default('src'),
@@ -15,8 +15,6 @@ export function parseCompilerConfig(config: any): CompilerConfig {
   return compilerConfigSchema.parse(config);
 }
 
-export type I18nConfig = Z.infer<typeof configFileSchema>;
-
 export function loadI18nConfig(): I18nConfig {
   const configFileName = 'i18n.json';
   const configFilePath = path.resolve(process.cwd(), configFileName);
@@ -26,5 +24,7 @@ export function loadI18nConfig(): I18nConfig {
   };
   const configFile = fs.readFileSync(configFilePath, 'utf-8');
   const configFileObj = JSON.parse(configFile);
-  return configFileSchema.parse(configFileObj);
+
+  const result = parseI18nConfig(configFileObj);
+  return result;
 }

--- a/packages/compiler/src/next.ts
+++ b/packages/compiler/src/next.ts
@@ -3,8 +3,8 @@ import type { NextConfig } from 'next';
 import Z from 'zod';
 import type { Configuration as WebpackConfig } from 'webpack';
 
-import { I18nConfig } from "./config";
 import unplg from './unplg';
+import { I18nConfig } from '@replexica/spec';
 
 const nextCompilerConfigSchema = Z.object({
   sourceRoot: Z.string().optional().default('src'),

--- a/packages/compiler/src/stub.ts
+++ b/packages/compiler/src/stub.ts
@@ -1,4 +1,5 @@
-import { CompilerConfig, I18nConfig } from "./config";
+import { I18nConfig } from "@replexica/spec";
+import { CompilerConfig } from "./config";
 
 export default function (compilerConfig: CompilerConfig, i18nConfig: I18nConfig) {
   return { stub: true };

--- a/packages/react/src/next/middleware.ts
+++ b/packages/react/src/next/middleware.ts
@@ -1,5 +1,5 @@
 import { NextFetchEvent, NextResponse, type NextRequest } from "next/server";
-import { configFileSchema } from '@replexica/spec';
+import { I18nConfig } from '@replexica/spec';
 import { createLocaleCookieString, createLocaleExtractor, createLocalePicker } from "./utils";
 import { LocalizedURL } from "../shared/localized-url";
 
@@ -11,7 +11,7 @@ const defaultParams: NextI18nMiddlewareParams = {
   // explicitDefaultLocale: false,
 };
 
-export const createI18nMiddleware = (i18nConfig: typeof configFileSchema._type, params = defaultParams) =>
+export const createI18nMiddleware = (i18nConfig: I18nConfig, params = defaultParams) =>
   (originalMiddleware = async (_req: NextRequest, _event: NextFetchEvent) => NextResponse.next()) =>
     async (req: NextRequest, event: NextFetchEvent) => {
       const isHtmlRequest = req.headers.get('accept')?.includes('text/html');

--- a/packages/spec/src/config.spec.ts
+++ b/packages/spec/src/config.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { parseI18nConfig, I18nConfig, defaultConfig } from './config'; // Adjust the import path as needed
+
+// Helper function to create a v0 config
+const createV0Config = () => ({
+  version: 0,
+});
+
+// Helper function to create a v1 config
+const createV1Config = () => ({
+  version: 1,
+  locale: {
+    source: 'en',
+    targets: ['es'],
+  },
+  buckets: {
+    'src/ui/[locale]/.json': 'json',
+    'src/blog/[locale]/*.md': 'markdown',
+  },
+});
+
+// Helper function to create a v1.1 config
+const createV1_1Config = () => ({
+  version: 1.1,
+  locale: {
+    source: 'en',
+    targets: ['es', 'fr'],
+  },
+  buckets: {
+    json: {
+      include: [
+        'src/ui/[locale]/.json',
+      ]
+    },
+    markdown: {
+      include: [
+        'src/blog/[locale]/*.md',
+      ],
+      exclude: [
+        'src/blog/[locale]/drafts.md',
+      ],
+    },
+  },
+});
+
+describe('I18n Config Parser', () => {
+  it('should upgrade v0 config to v1.1', () => {
+    const v0Config = createV0Config();
+    const result = parseI18nConfig(v0Config);
+    
+    expect(result.version).toBe(1.1);
+    expect(result.locale).toEqual(defaultConfig.locale);
+    expect(result.buckets).toEqual({});
+  });
+
+  it('should upgrade v1 config to v1.1', () => {
+    const v1Config = createV1Config();
+    const result = parseI18nConfig(v1Config);
+    
+    expect(result.version).toBe(1.1);
+    expect(result.locale).toEqual(v1Config.locale);
+    expect(result.buckets).toEqual({
+      json: {
+        include: [
+          'src/ui/[locale]/.json',
+        ]
+      },
+      markdown: {
+        include: [
+          'src/blog/[locale]/*.md',
+        ],
+      },
+    });
+  });
+
+  it('should not modify v1.1 config', () => {
+    const v1_1Config = createV1_1Config();
+    const result = parseI18nConfig(v1_1Config);
+    
+    expect(result).toEqual(v1_1Config);
+  });
+
+  it('should throw an error for invalid configurations', () => {
+    const invalidConfig = { version: 'invalid' };
+    expect(() => parseI18nConfig(invalidConfig)).toThrow('Failed to parse config');
+  });
+
+  it('should handle empty config and use defaults', () => {
+    const emptyConfig = {};
+    const result = parseI18nConfig(emptyConfig);
+    
+    expect(result).toEqual(defaultConfig);
+  });
+
+  it('should ignore extra fields in the config', () => {
+    const configWithExtra = {
+      ...createV1_1Config(),
+      extraField: 'should be ignored',
+    };
+    const result = parseI18nConfig(configWithExtra);
+    
+    expect(result).not.toHaveProperty('extraField');
+    expect(result).toEqual(createV1_1Config());
+  });
+});

--- a/packages/spec/src/config.ts
+++ b/packages/spec/src/config.ts
@@ -121,7 +121,11 @@ const configV1_1Definition = extendConfigDefinition(configV1Definition, {
     if (config.buckets) {
       for (const [key, value] of Object.entries(config.buckets)) {
         upgradedConfig.buckets[value] = {
-          paths: [key],
+          ...upgradedConfig.buckets[value],
+          paths: [
+            ...(upgradedConfig.buckets[value]?.paths || []),
+            key,
+          ],
         };
       }
     }
@@ -144,3 +148,5 @@ export function parseI18nConfig(rawConfig: unknown) {
     throw new Error(`Failed to parse config: ${error.message}`);
   }
 }
+
+export const defaultConfig = LATEST_CONFIG_DEFINITION.defaultValue;

--- a/packages/spec/src/config.ts
+++ b/packages/spec/src/config.ts
@@ -2,23 +2,145 @@ import Z from 'zod';
 import { sourceLocaleSchema, targetLocaleSchema } from './locales';
 import { bucketTypeSchema } from './formats';
 
+// common
 export const localeSchema = Z.object({
   source: sourceLocaleSchema,
   targets: Z.array(targetLocaleSchema),
 });
 
-export const configFileSchema = Z.object({
-  locale: localeSchema,
-  buckets: Z.record(
-    Z.string(),
-    bucketTypeSchema,
-  ).default({}).optional(),
+// factories
+type ConfigDefinition<T extends Z.ZodRawShape, P extends Z.ZodRawShape> = {
+  schema: Z.ZodObject<T>;
+  defaultValue: Z.infer<Z.ZodObject<T>>;
+  parse: (rawConfig: unknown) => Z.infer<Z.ZodObject<T>>;
+};
+const createConfigDefinition = <T extends Z.ZodRawShape, P extends Z.ZodRawShape>(
+  definition: ConfigDefinition<T, P>,
+) => definition;
+
+
+type ConfigDefinitionExtensionParams<T extends Z.ZodRawShape, P extends Z.ZodRawShape> = {
+  createSchema: (baseSchema: Z.ZodObject<P>) => Z.ZodObject<T>;
+  createDefaultValue: (baseDefaultValue: Z.infer<Z.ZodObject<P>>) => Z.infer<Z.ZodObject<T>>;
+  createUpgrader: (
+    config: Z.infer<Z.ZodObject<P>>,
+    schema: Z.ZodObject<T>,
+    defaultValue: Z.infer<Z.ZodObject<T>>,
+  ) => Z.infer<Z.ZodObject<T>>;
+};
+const extendConfigDefinition = <T extends Z.ZodRawShape, P extends Z.ZodRawShape>(
+  definition: ConfigDefinition<P, any>,
+  params: ConfigDefinitionExtensionParams<T, P>,
+) => {
+  const schema = params.createSchema(definition.schema);
+  const defaultValue = params.createDefaultValue(definition.defaultValue);
+  const upgrader = (config: Z.infer<Z.ZodObject<P>>) => params.createUpgrader(config, schema, defaultValue);
+
+  return createConfigDefinition({
+    schema,
+    defaultValue,
+    parse: (rawConfig) => {
+      const safeResult = schema.safeParse(rawConfig);
+      if (safeResult.success) {
+        return safeResult.data;
+      }
+
+      const baseConfig = definition.parse(rawConfig);
+      const result = upgrader(baseConfig);
+      return result;
+    }
+  });
+};
+
+// any -> v0
+const configV0Schema = Z.object({
+  version: Z.number().default(0),
+});
+const configV0Definition = createConfigDefinition({
+  schema: configV0Schema,
+  defaultValue: { version: 0 },
+  parse: (rawConfig) => {
+    return configV0Schema.parse(rawConfig);
+  },
 });
 
-export const defaultConfig: Z.infer<typeof configFileSchema> = {
-  locale: {
-    source: 'en',
-    targets: ['es'],
+// v0 -> v1
+const configV1Definition = extendConfigDefinition(configV0Definition, {
+  createSchema: (baseSchema) => baseSchema.extend({
+    locale: localeSchema,
+    buckets: Z.record(
+      Z.string(),
+      bucketTypeSchema,
+    ).default({}).optional(),
+  }),
+  createDefaultValue: () => ({
+    version: 1,
+    locale: {
+      source: 'en' as const,
+      targets: [
+        'es' as const,
+      ],
+    },
+    buckets: {},
+  }),
+  createUpgrader: () => ({
+    version: 1,
+    locale: {
+      source: 'en' as const,
+      targets: [
+        'es' as const,
+      ],
+    },
+    buckets: {},
+  }),
+});
+
+// v1 -> v1.1
+const configV1_1Definition = extendConfigDefinition(configV1Definition, {
+  createSchema: (baseSchema) => baseSchema.extend({
+    buckets: Z.record(
+      bucketTypeSchema,
+      Z.object({
+        paths: Z.array(Z.string()).default([]),
+      })
+    ).default({}),
+  }),
+  createDefaultValue: (baseDefaultValue) => ({
+    ...baseDefaultValue,
+    version: 1.1,
+    buckets: {},
+  }),
+  createUpgrader: (config, schema) => {
+    const upgradedConfig: Z.infer<typeof schema> = {
+      ...config,
+      version: 1.1,
+      buckets: {},
+    };
+
+    // Transform buckets from v1 to v1.1 format
+    if (config.buckets) {
+      for (const [key, value] of Object.entries(config.buckets)) {
+        upgradedConfig.buckets[value] = {
+          paths: [key],
+        };
+      }
+    }
+
+    return upgradedConfig;
   },
-  buckets: {},
-};
+});
+
+
+// exports
+const LATEST_CONFIG_DEFINITION = configV1_1Definition;
+
+export type I18nConfig = Z.infer<typeof LATEST_CONFIG_DEFINITION['schema']>;
+
+export function parseI18nConfig(rawConfig: unknown) {
+  try {
+    const result = LATEST_CONFIG_DEFINITION.parse(rawConfig);
+    return result;
+  } catch (error: any) {
+    throw new Error(`Failed to parse config: ${error.message}`);
+  }
+}

--- a/packages/spec/src/config.ts
+++ b/packages/spec/src/config.ts
@@ -126,7 +126,7 @@ const configV1_1Definition = extendConfigDefinition(configV1Definition, {
             include: [],
           };
         }
-        upgradedConfig.buckets[bucketType].include.push(bucketPath);
+        upgradedConfig.buckets[bucketType]?.include.push(bucketPath);
       }
     }
 

--- a/packages/spec/src/config.ts
+++ b/packages/spec/src/config.ts
@@ -56,7 +56,7 @@ const extendConfigDefinition = <T extends Z.ZodRawShape, P extends Z.ZodRawShape
 const configV0Schema = Z.object({
   version: Z.number().default(0),
 });
-const configV0Definition = createConfigDefinition({
+export const configV0Definition = createConfigDefinition({
   schema: configV0Schema,
   defaultValue: { version: 0 },
   parse: (rawConfig) => {
@@ -65,7 +65,7 @@ const configV0Definition = createConfigDefinition({
 });
 
 // v0 -> v1
-const configV1Definition = extendConfigDefinition(configV0Definition, {
+export const configV1Definition = extendConfigDefinition(configV0Definition, {
   createSchema: (baseSchema) => baseSchema.extend({
     locale: localeSchema,
     buckets: Z.record(
@@ -96,7 +96,7 @@ const configV1Definition = extendConfigDefinition(configV0Definition, {
 });
 
 // v1 -> v1.1
-const configV1_1Definition = extendConfigDefinition(configV1Definition, {
+export const configV1_1Definition = extendConfigDefinition(configV1Definition, {
   createSchema: (baseSchema) => baseSchema.extend({
     buckets: Z.record(
       bucketTypeSchema,


### PR DESCRIPTION
Major upgrade:

`i18n.json` now supports file exclusions. Here's how:

```json
"buckets": {
  "markdown": {
    "include": [
      "demo/markdown-multi/[locale]/*.md",
      "demo/markdown/[locale].md"
    ],
    "exclude": [
      "demo/markdown-multi/[locale]/ignored-blog-post.md"
    ]
  }
},
```

Key changes:

1. Bucket type (i.e. `markdown`, `json`, etc) is now the *key* in the `buckets` object map.
2. Each bucket configuration node has two fields: `include` (required) and `exclude` (optional).

Example: Despite `ignored-blog-post.md` matching the `demo/markdown-multi/[locale]/*.md` pattern, `replexica i18n` ignores it due to the `exclude` field entry.

--

Resolves #151 