### PR TITLE
feat(cli): add `replexica lockfile` for explicit lockfile generation

### DIFF
--- a/.changeset/red-books-complain.md
+++ b/.changeset/red-books-complain.md
@@ -1,0 +1,6 @@
+---
+"@replexica/cli": patch
+"replexica": patch
+---
+
+Add replexica lockfile command for explicit lockfile generation

--- a/packages/cli/src/cli/i18n.ts
+++ b/packages/cli/src/cli/i18n.ts
@@ -44,24 +44,6 @@ export default new Command()
         ora.succeed('Replexica configuration loaded');
       }
 
-      // ora.start('Deleting redundant i18n files');
-      // let i18nLocales = [i18nConfig.locale.source, ...i18nConfig.locale.targets]
-      // for (const bucketPath of Object.keys(i18nConfig.buckets)) {
-      //   let directory = bucketPath.substring(0, bucketPath.lastIndexOf('/'));
-      //   let parentDir = path.join(process.cwd(), directory);
-
-      //   fs.readdirSync(parentDir).forEach(file => {
-      //     let fileName = file.substring(file.lastIndexOf('/') + 1);
-      //     let locale = fileName.substring(0, fileName.indexOf('.'));
-      //     const exists = i18nLocales.includes(locale);
-      //     if (!exists) {
-      //       let dir = parentDir + "/" + file;
-      //       fs.unlinkSync(dir);
-      //     }
-      //   })
-      // }
-      // ora.succeed('Redundant i18n files deleted')
-
       ora.start('Connecting to AI localization engine');
       const authenticator = createAuthenticator({
         apiKey: settings.auth.apiKey,

--- a/packages/cli/src/cli/index.ts
+++ b/packages/cli/src/cli/index.ts
@@ -8,8 +8,7 @@ import authCmd from './auth';
 import initCmd from './init';
 import configCmd from './show';
 import i18nCmd from './i18n';
-import path from 'path';
-import fs from 'fs';
+import lockfileCmd from './lockfile';
 
 import packageJson from '../../package.json';
 
@@ -32,6 +31,7 @@ Website: https://replexica.com
   .addCommand(authCmd)
   .addCommand(initCmd)
   .addCommand(configCmd)
+  .addCommand(lockfileCmd)
   .parse(process.argv)
 ;
 

--- a/packages/cli/src/cli/init.ts
+++ b/packages/cli/src/cli/init.ts
@@ -20,3 +20,4 @@ export default new Command()
 
     spinner.succeed('Replexica project initialized');
   });
+  

--- a/packages/cli/src/cli/lockfile.ts
+++ b/packages/cli/src/cli/lockfile.ts
@@ -1,0 +1,62 @@
+import { Command } from 'commander';
+import Z from 'zod';
+import Ora from 'ora';
+import { createLockfileProcessor } from '../workers/lockfile';
+import { bucketTypeSchema } from '@replexica/spec';
+import { loadConfig } from '../workers/config';
+import { createBucketLoader, expandPlaceholderedGlob } from '../workers/bucket/v2';
+
+export default new Command()
+  .command('lockfile')
+  .description('Create a lockfile if it does not exist')
+  .helpOption('-h, --help', 'Show help')
+  .option('-f, --force', 'Force create a lockfile')
+  .action(async (options) => {
+    const flags = flagsSchema.parse(options);
+    const ora = Ora().start('Creating lockfile');
+
+    const lockfileProcessor = createLockfileProcessor();
+    const lockfileExists = await lockfileProcessor.exists();
+    if (lockfileExists && !flags.force) {
+      ora.warn(`Lockfile won't be created because it already exists. Use --force to overwrite.`);
+      return;
+    } else {
+      await lockfileProcessor.delete();
+    }
+
+    const i18nConfig = await loadConfig();
+
+    const placeholderedPathsTuples: [Z.infer<typeof bucketTypeSchema>, string][] = [];
+    for (const [bucketType, bucketTypeParams] of Object.entries(i18nConfig?.buckets || {})) {
+      const includedPlaceholderedPaths = bucketTypeParams.include
+        .map((placeholderedGlob) => expandPlaceholderedGlob(placeholderedGlob, i18nConfig!.locale.source))
+        .flat();
+      const excludedPlaceholderedPaths = bucketTypeParams.exclude
+        ?.map((placeholderedGlob) => expandPlaceholderedGlob(placeholderedGlob, i18nConfig!.locale.source))
+        .flat() || [];
+      const finalPlaceholderedPaths = includedPlaceholderedPaths.filter((path) => !excludedPlaceholderedPaths.includes(path));
+      for (const placeholderedPath of finalPlaceholderedPaths) {
+        placeholderedPathsTuples.push([
+          bucketType as Z.infer<typeof bucketTypeSchema>,
+          placeholderedPath
+        ]);
+      }
+    }
+
+    for (const [bucketType, placeholderedPath] of placeholderedPathsTuples) {
+      const sourcePayload = await createBucketLoader({
+        bucketType,
+        placeholderedPath,
+        locale: i18nConfig!.locale.source,
+      }).load();
+
+      const currentChecksums = await lockfileProcessor.createChecksums(sourcePayload);
+      await lockfileProcessor.saveChecksums(placeholderedPath, currentChecksums);
+    }
+
+    ora.succeed('Lockfile created');
+  });
+
+const flagsSchema = Z.object({
+  force: Z.boolean().default(false),
+});

--- a/packages/cli/src/workers/lockfile.ts
+++ b/packages/cli/src/workers/lockfile.ts
@@ -9,6 +9,15 @@ export type LockfilePayload = Z.infer<typeof LockfileSchema>;
 
 export function createLockfileProcessor() {
   return {
+    async delete(): Promise<void> {
+      const lockfilePath = _getLockfilePath();
+      if (fs.existsSync(lockfilePath)) {
+        fs.unlinkSync(lockfilePath);
+      }
+    },
+    async exists(): Promise<boolean> {
+      return fs.existsSync(_getLockfilePath());
+    },
     async load(): Promise<LockfilePayload> {
       const lockfilePath = _getLockfilePath();
     


### PR DESCRIPTION
Adding `replexica lockfile` command, to simplify initial onboarding for user who's already got some translation files in place.

Resolves #120 