### PR TITLE
feat: Added 2 new github issue templates

### DIFF
--- a/.changeset/nasty-buttons-act.md
+++ b/.changeset/nasty-buttons-act.md
@@ -1,0 +1,5 @@
+---
+"replexica": patch
+---
+
+Added 2 new github issue forms

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,87 @@
+name: "Bug Report"
+description: "Please fill out the following details to report a bug."
+title: "[BUG] - <title>"
+labels: ["bug"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: "Please enter an explicit description of your issue."
+      placeholder: "Short and explicit description of your issue..."
+    validations:
+      required: true
+  - type: input
+    id: cli-version
+    attributes:
+      label: "CLI Version"
+      description: "Please enter the CLI version you're using."
+      placeholder: "e.g. v1.0"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: "Operating System"
+      description: "What is the impacted environment?"
+      options:
+        - Windows
+        - Linux
+        - macOS
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: "Steps to Reproduce"
+      description: "Please provide explicit steps to reproduce the issue."
+      value: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: "Expected vs Actual Behavior"
+      description: "Please describe what you expected to happen vs what actually happened."
+      placeholder: "Expected: ... / Actual: ..."
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: "Screenshots"
+      description: "If applicable, add screenshots to help explain your problem."
+      placeholder: "Paste screenshot links or markdown here..."
+    validations:
+      required: false
+  - type: checkboxes
+    id: browsers
+    attributes:
+      label: "Browsers"
+      description: "What browsers are you seeing the problem on? (Select all that apply)"
+      options:
+        - label: Firefox
+        - label: Chrome
+        - label: Safari
+        - label: Microsoft Edge
+        - label: Opera
+        - label: Other
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: "Additional Context"
+      description: "Add any other context about the problem here."
+      placeholder: "Additional context (if any)..."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: "Feature/Improvement Request"
+description: "Suggest a new feature or improvement for the project."
+title: " [FEATURE] - <title>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: "WHAT"
+      description: "What feature or improvement would you like to request?"
+      placeholder: "Describe the feature or improvement..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: "WHY"
+      description: "Why is this feature or improvement important? What problem does it solve or what benefit does it bring?"
+      placeholder: "Explain the need or benefit..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: how
+    attributes:
+      label: "HOW"
+      description: "If you have an idea, describe how this feature could be implemented."
+      placeholder: "Provide suggestions on implementation (if applicable)..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: "Additional Context"
+      description: "Any additional information or context about this request."
+      placeholder: "Additional context (if any)..."
+    validations:
+      required: false


### PR DESCRIPTION
This PR resolves #112 , and it implements 2 new github issue forms which can help any user to create new issues the repository in a easier and more defined way



Screenshots:

Feature-request:
![Screenshot from 2024-10-10 15-05-49](https://github.com/user-attachments/assets/b818b485-7b42-4a0b-9c4f-051057a2bc05)
Bug-report:
![Screenshot from 2024-10-10 15-03-38](https://github.com/user-attachments/assets/5091a8a7-162f-4ed7-8c9f-63e94ee4b413)
