### PR TITLE
fix: prevent overwriting i18n.json for unsupported locales

### DIFF
--- a/.changeset/shaggy-beans-whisper.md
+++ b/.changeset/shaggy-beans-whisper.md
@@ -1,0 +1,6 @@
+---
+"replexica": minor
+"@replexica/cli": minor
+---
+
+prevented overwritting of i18n.json with a default template for unsupported locales

--- a/packages/cli/src/cli/i18n.ts
+++ b/packages/cli/src/cli/i18n.ts
@@ -28,7 +28,7 @@ export default new Command()
         i18nConfig,
         flags,
       ] = await Promise.all([
-        loadConfig(),
+        loadConfig(false),
         loadFlags(options),
       ]);
       const settings = await loadSettings(flags.apiKey);

--- a/packages/cli/src/cli/i18n.ts
+++ b/packages/cli/src/cli/i18n.ts
@@ -28,7 +28,7 @@ export default new Command()
         i18nConfig,
         flags,
       ] = await Promise.all([
-        loadConfig(false),
+        loadConfig(),
         loadFlags(options),
       ]);
       const settings = await loadSettings(flags.apiKey);

--- a/packages/spec/src/config.spec.ts
+++ b/packages/spec/src/config.spec.ts
@@ -48,6 +48,18 @@ const createV1_2Config = () => ({
   version: 1.2,
 });
 
+const createInvalidLocaleConfig = () => ({
+  version: 1,
+  locale: {
+    source: 'bbbb',
+    targets: ['es', 'aaaa'],
+  },
+  buckets: {
+    'src/ui/[locale]/.json': 'json',
+    'src/blog/[locale]/*.md': 'markdown',
+  },
+});
+
 describe('I18n Config Parser', () => {
   it('should upgrade v0 config to v1.2', () => {
     const v0Config = createV0Config();
@@ -106,5 +118,11 @@ describe('I18n Config Parser', () => {
     
     expect(result).not.toHaveProperty('extraField');
     expect(result).toEqual(createV1_1Config());
+  });
+
+  it('should throw an error for unsupported locales', () => {
+    const invalidLocaleConfig = createInvalidLocaleConfig();
+    expect(() => parseI18nConfig(invalidLocaleConfig))
+      .toThrow(`\nUnsupported locale: ${invalidLocaleConfig.locale.source}\nUnsupported locale: ${invalidLocaleConfig.locale.targets[1]}`);
   });
 });


### PR DESCRIPTION
Fixes: #198 

This PR modifies the CLI to prevent overwriting i18n.json with a default template when an unsupported locale is provided. Instead of allowing the file to be overwritten, the CLI now checks for unsupported locales and throws a clear error message if one is detected.