### PR TITLE
feat: add ability to skip i18n processing when commit message contain…

### DIFF
--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -101,6 +101,15 @@ create_or_update_pr() {
     fi
 }
 
+check_skip_i18n() {
+    local commit_message="$REPLEXICA_COMMIT_MESSAGE"
+
+    if [[ "$commit_message" =~ \[\ *[sS][kK][iI][pP]\ +[iI]18[nN]\ *\] ]]; then
+        echo "::notice::i18n processing has been skipped due to '[skip i18n]' found in the commit message."
+        exit 0
+    fi
+}
+
 # Main execution
 main() {
     # Configure git for committing changes
@@ -112,6 +121,9 @@ main() {
             exit 1
         fi
     fi
+
+    # Check commit message for skip i18n
+    check_skip_i18n
 
     # Run Replexica to update translations
     run_replexica


### PR DESCRIPTION
Fixes: #192

This PR introduces a new feature in custom GitHub Action that allows developers to bypass i18n processing by including the string `'[skip i18n]'` in their commit message. This is particularly useful for debugging GitHub workflows, enabling teams to quickly skip i18n checks as needed.