### PR TITLE
#192 feat:Action skip on commit message contains '[skip i18n]'

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,6 +17,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{github.event.pull_request.head.sha}}
+          fetch-depth: 0
+          
       - name: Check for [skip i18n]
         run: |
           COMMIT_MESSAGE=$(git log -1 --pretty=%B)
@@ -24,12 +30,6 @@ jobs:
             echo "Skipping i18n checks due to [skip i18n] in commit message."
             exit 0
           fi
-
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: ${{github.event.pull_request.head.sha}}
-          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v2

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -31,7 +31,7 @@ jobs:
           COMMIT_MESSAGE=$(git log -1 --pretty=%B)
           if echo "$COMMIT_MESSAGE" | grep -iq '\[skip i18n\]'; then
             echo "Skipping i18n checks due to [skip i18n] in commit message."
-            exit 0
+            exit 1
           fi
 
       - name: Use Node.js

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -72,3 +72,5 @@ jobs:
       - name: Require changeset to be present in PR
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: pnpm changeset status --since origin/main
+
+

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,9 +2,6 @@ name: Check PR
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,6 +17,14 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Check for [skip i18n]
+        run: |
+          COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+          if echo "$COMMIT_MESSAGE" | grep -iq '\[skip i18n\]'; then
+            echo "Skipping i18n checks due to [skip i18n] in commit message."
+            exit 0
+          fi
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -75,5 +75,3 @@ jobs:
       - name: Require changeset to be present in PR
         if: github.event.pull_request.user.login != 'dependabot[bot]'
         run: pnpm changeset status --since origin/main
-
-

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -2,6 +2,9 @@ name: Check PR
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
   pull_request_target:
     types:
       - opened

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Check for [skip i18n]
+        run: |
+          COMMIT_MESSAGE=$(git log -1 --pretty=%B)
+          if echo "$COMMIT_MESSAGE" | grep -iq '\[skip i18n\]'; then
+            echo "Skipping i18n checks due to [skip i18n] in commit message."
+            exit 1
+          fi
 
       - name: Use Node.js
         uses: actions/setup-node@v2


### PR DESCRIPTION
This PR introduces a new feature in custom GitHub Action that allows developers to bypass Github action workflows by including the string '[skip i18n]' in their commit message, enabling teams to quickly skip i18n checks as needed.

This pr adds the skip to the pr-check and release workflows tell me if u want to do that for the pr-lint workflow as well ;D