### PR TITLE
fix(cli): add early exit for --frozen flag if lockfile update required

### DIFF
--- a/.changeset/fuzzy-feet-buy.md
+++ b/.changeset/fuzzy-feet-buy.md
@@ -1,0 +1,5 @@
+---
+"@replexica/cli": minor
+---
+
+--frozen flag

--- a/.changeset/fuzzy-feet-buy.md
+++ b/.changeset/fuzzy-feet-buy.md
@@ -1,5 +1,6 @@
 ---
 "@replexica/cli": minor
+"replexica": minor
 ---
 
 --frozen flag


### PR DESCRIPTION
Ensures that the --frozen flag exits before entering the localization loop if lockfile changes are detected, preventing unnecessary processing and API calls. Useful for CI/CD workflows to check localization changes.

Closes #110 