### PR TITLE
feat(cli): Add XLIFF Loader with TypeScript Compatibility Fix

### DIFF
--- a/.changeset/selfish-pens-happen.md
+++ b/.changeset/selfish-pens-happen.md
@@ -1,0 +1,6 @@
+---
+"@replexica/spec": minor
+"@replexica/cli": minor
+---
+
+added support for xliff loader

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -48,6 +48,7 @@
     "slugify": "^1.6.6",
     "typescript": "^5.6.3",
     "vitest": "^2.1.4",
+    "xliff": "^6.2.1",
     "xml2js": "^0.6.2",
     "xmldom": "^0.6.0",
     "xpath": "^0.0.34",

--- a/packages/cli/src/loaders/index.spec.ts
+++ b/packages/cli/src/loaders/index.spec.ts
@@ -859,6 +859,175 @@ user.password=Contraseña
       );
     });
   });
+  describe('xliff bucket loader', () => {
+    it('should load xliff data', async () => {
+      setupFileMocks();
+  
+      const input = `
+  <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US">
+    <file id="namespace1">
+      <unit id="key1">
+        <segment>
+          <source>Hello</source>
+        </segment>
+      </unit>
+      <unit id="key2">
+        <segment>
+          <source>An application to manipulate and process XLIFF documents</source>
+        </segment>
+      </unit>
+      <unit id="key.nested">
+        <segment>
+          <source>XLIFF Data Manager</source>
+        </segment>
+      </unit>
+      <group id="group">
+        <unit id="groupUnit">
+          <segment>
+            <source>Group</source>
+          </segment>
+        </unit>
+      </group>
+    </file>
+  </xliff>
+      `.trim();
+      
+      const expectedOutput =  {
+        "resources":  {
+             "namespace1":  {
+               "group":  {
+                 "groupUnits":  {
+                   "groupUnit":  {
+                     "source": "Group",
+                   },
+                 },
+                },
+                "key.nested":  {
+                 "source": "XLIFF Data Manager",
+               },
+               "key1":  {
+                 "source": "Hello",
+              },
+               "key2":  {
+                 "source": "An application to manipulate and process XLIFF documents",
+                },
+             },
+           },
+           "sourceLanguage": "en-US",
+          };
+  
+          mockFileOperations(input);
+          
+          const xliffLoader = createBucketLoader('xliff', 'i18n/[locale].xliff');
+          xliffLoader.setDefaultLocale('en');
+          const data = await xliffLoader.pull('en');
+          
+          expect(data).toEqual(expectedOutput);
+        });
+        
+        it('should save xliff data', async () => {
+          setupFileMocks();
+          
+        const input = `
+    <xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US">
+      <file id="namespace1">
+        <unit id="key1">
+          <segment>
+            <source>Hello</source>
+          </segment>
+        </unit>
+        <unit id="key2">
+          <segment>
+            <source>An application to manipulate and process XLIFF documents</source>
+          </segment>
+        </unit>
+        <unit id="key.nested">
+          <segment>
+            <source>XLIFF Data Manager</source>
+          </segment>
+        </unit>
+        <group id="group">
+          <unit id="groupUnit">
+            <segment>
+              <source>Group</source>
+            </segment>
+          </unit>
+        </group>
+      </file>
+    </xliff>
+        `.trim();
+        const payload =  {
+          "resources":  {
+            "namespace1":  {
+              "group":  {
+                "groupUnits":  {
+                  "groupUnit":  {
+                    "source": "Grupo",
+                  },
+                },
+              },
+              "key.nested":  {
+                "source": "Administrador de Datos XLIFF",
+              },
+              "key1":  {
+                "source": "Hola",
+              },
+              "key2":  {
+                "source": "Una aplicación para manipular y procesar documentos XLIFF",
+              },
+            },
+          },
+          "sourceLanguage": "es-ES",
+        };
+        
+    
+        const expectedOutput = `
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="es-ES">
+  <file id="namespace1">
+    <unit id="key1">
+      <segment>
+        <source>Hola</source>
+      </segment>
+    </unit>
+    <unit id="key2">
+      <segment>
+        <source>Una aplicación para manipular y procesar documentos XLIFF</source>
+      </segment>
+    </unit>
+    <unit id="key.nested">
+      <segment>
+        <source>Administrador de Datos XLIFF</source>
+      </segment>
+    </unit>
+    <group id="group">
+      <unit id="groupUnit">
+        <segment>
+          <source>Grupo</source>
+        </segment>
+      </unit>
+    </group>
+  </file>
+</xliff>
+`.trim()+"\n";
+
+  
+      mockFileOperations(input);
+  
+      const xliffLoader = createBucketLoader('xliff', 'i18n/[locale].xliff');
+      xliffLoader.setDefaultLocale('en');
+      await xliffLoader.pull('en');
+  
+      await xliffLoader.push('es', payload);
+  
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        'i18n/es.xliff',
+        expectedOutput,
+        { encoding: 'utf-8', flag: 'w' }
+      );
+    });
+  });
+  
+  
 });
 
 // Helper functions

--- a/packages/cli/src/loaders/index.ts
+++ b/packages/cli/src/loaders/index.ts
@@ -19,6 +19,7 @@ import createXcodeXcstringsLoader from './xcode-xcstrings';
 import createPrettierLoader from './prettier';
 import createUnlocalizableLoader from './unlocalizable';
 import createPoLoader from './po';
+import createXliffLoader from './xliff';
 
 export default function createBucketLoader(
   bucketType: Z.infer<typeof bucketTypeSchema>,
@@ -109,5 +110,12 @@ export default function createBucketLoader(
       createFlatLoader(),
       createUnlocalizableLoader(),
     );
+    case 'xliff': return composeLoaders(
+      createTextFileLoader(bucketPathPattern),
+      // createPrettierLoader({ parser: 'xliff' }),
+      createXliffLoader(),
+      // createFlatLoader(),
+      createUnlocalizableLoader(),
+    )
   }
 }

--- a/packages/cli/src/loaders/xliff.ts
+++ b/packages/cli/src/loaders/xliff.ts
@@ -1,0 +1,25 @@
+import * as xliff2js from 'xliff/xliff2js';
+import * as js2xliff from 'xliff/js2xliff';
+
+const xliff2jsAny = xliff2js as any;
+const js2xliffAny = js2xliff as any;
+
+
+
+import { ILoader } from "./_types";
+import { createLoader } from './_utils';
+
+// const xliff2jsAsAny: any = xliff2js;
+// const js2xliffAsAny: any = js2xliff;
+
+export default function createXliffLoader(): ILoader<string, Record<string, any>> {
+  return createLoader({
+    async pull(locale, input) {
+      const js = await xliff2jsAny(input)
+      return js || {};
+    },
+    async push(locale, payload) {      
+      return await js2xliffAny(payload);
+    }
+  });
+}

--- a/packages/cli/src/loaders/xliff.ts
+++ b/packages/cli/src/loaders/xliff.ts
@@ -1,25 +1,17 @@
-import * as xliff2js from 'xliff/xliff2js';
-import * as js2xliff from 'xliff/js2xliff';
-
-const xliff2jsAny = xliff2js as any;
-const js2xliffAny = js2xliff as any;
-
-
-
+const xliff2js: any = require('xliff/xliff2js');
+const js2xliff: any = require('xliff/js2xliff');
 import { ILoader } from "./_types";
 import { createLoader } from './_utils';
 
-// const xliff2jsAsAny: any = xliff2js;
-// const js2xliffAsAny: any = js2xliff;
 
 export default function createXliffLoader(): ILoader<string, Record<string, any>> {
   return createLoader({
     async pull(locale, input) {
-      const js = await xliff2jsAny(input)
+      const js = await xliff2js(input)
       return js || {};
     },
     async push(locale, payload) {      
-      return await js2xliffAny(payload);
+      return await js2xliff(payload);
     }
   });
 }

--- a/packages/spec/src/formats.ts
+++ b/packages/spec/src/formats.ts
@@ -14,7 +14,7 @@ export const bucketTypes = [
   'yaml-root-key',
   'properties',
   'po',
-
+  'xliff',
   'compiler',
 ] as const;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       vitest:
         specifier: ^2.1.4
         version: 2.1.4(@types/node@22.8.4)(jsdom@25.0.1)(terser@5.36.0)
+      xliff:
+        specifier: ^6.2.1
+        version: 6.2.1
       xml2js:
         specifier: ^0.6.2
         version: 0.6.2
@@ -300,7 +303,7 @@ importers:
         version: 3.0.6
       '@types/webpack':
         specifier: ^5.28.5
-        version: 5.28.5(esbuild@0.24.0)
+        version: 5.28.5
       next:
         specifier: ^14.2.14
         version: 14.2.14(@babel/core@7.26.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1400,6 +1403,7 @@ packages:
 
   acorn-import-assertions@1.9.0:
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
+    deprecated: package has been renamed to acorn-import-attributes
     peerDependencies:
       acorn: ^8
 
@@ -3492,6 +3496,13 @@ packages:
       utf-8-validate:
         optional: true
 
+  xliff@6.2.1:
+    resolution: {integrity: sha512-uLdfmBHCG4ftZdgLHhzP7qFTt8/pOv4Hpr1lWcX0HKLZdvhu5f7zThLlPFHnXH7mHbFT+6LCaf82UB3zbLpweQ==}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -4503,11 +4514,11 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
-  '@types/webpack@5.28.5(esbuild@0.24.0)':
+  '@types/webpack@5.28.5':
     dependencies:
       '@types/node': 22.8.4
       tapable: 2.2.1
-      webpack: 5.91.0(esbuild@0.24.0)
+      webpack: 5.91.0
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -6285,16 +6296,14 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.10(esbuild@0.24.0)(webpack@5.91.0(esbuild@0.24.0)):
+  terser-webpack-plugin@5.3.10(webpack@5.91.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       jest-worker: 27.5.1
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.31.0
-      webpack: 5.91.0(esbuild@0.24.0)
-    optionalDependencies:
-      esbuild: 0.24.0
+      webpack: 5.91.0
 
   terser@5.31.0:
     dependencies:
@@ -6560,7 +6569,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.91.0(esbuild@0.24.0):
+  webpack@5.91.0:
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.5
@@ -6583,7 +6592,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(esbuild@0.24.0)(webpack@5.91.0(esbuild@0.24.0))
+      terser-webpack-plugin: 5.3.10(webpack@5.91.0)
       watchpack: 2.4.1
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -6645,6 +6654,14 @@ snapshots:
       strip-ansi: 7.1.0
 
   ws@8.18.0: {}
+
+  xliff@6.2.1:
+    dependencies:
+      xml-js: 1.6.11
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.4.1
 
   xml-name-validator@5.0.0: {}
 


### PR DESCRIPTION
### Summary:
Should close #291 
- Added XLIFF loader to handle translations.
- Used require for unsupported TypeScript modules to avoid missing declaration errors.
- Included tests for complex XLIFF structures.

**Notes:**
- require allows us to proceed without custom type definitions for now.