### PR TITLE
feat(cli): implemented the tmx loader and format changes

### DIFF
--- a/.changeset/quiet-pets-end.md
+++ b/.changeset/quiet-pets-end.md
@@ -1,0 +1,6 @@
+---
+"@replexica/cli": major
+"@replexica/spec": minor
+---
+
+feat: added tmx loader and format changes

--- a/packages/cli/src/loaders/index.spec.ts
+++ b/packages/cli/src/loaders/index.spec.ts
@@ -1009,6 +1009,127 @@ Mundo!\n`;
       });
   
   });
+
+
+
+  describe('tmx bucket loader', () => {
+    it('should load tmx', async () => {
+      setupFileMocks();
+
+      const input = `<?xml version="1.0" encoding="UTF-8"?>
+      <tmx version="1.4">
+        <header
+          creationtool="MyTranslationTool"
+          creationtoolversion="1.0"
+          segtype="sentence"
+          o-tmf="tmx"
+          adminlang="en-US"
+          srclang="en-US"
+          datatype="plaintext"
+        />
+        <body>
+          <tu>
+            <tuv xml:lang="en-US" creationdate="20240212T191726" lastusagedate="20240212T191726">
+              <seg>Hello, how are you?</seg>
+            </tuv>
+            <tuv xml:lang="fr-FR" creationdate="20240212T191726" lastusagedate="20240212T191726">
+              <seg>Bonjour, comment vas-tu?</seg>
+            </tuv>
+            <tuv xml:lang="es-ES" creationdate="20240212T191726" lastusagedate="20240212T191726">
+              <seg>Hola, ¿cómo estás?</seg>
+            </tuv>
+          </tu>
+          <tu>
+            <tuv xml:lang="en-US" creationdate="20240212T191726" lastusagedate="20240212T191726">
+              <seg>I am fine, thank you.</seg>
+            </tuv>
+            <tuv xml:lang="fr-FR" creationdate="20240212T191726" lastusagedate="20240212T191726">
+              <seg>Je vais bien, merci.</seg>
+            </tuv>
+            <tuv xml:lang="es-ES" creationdate="20240212T191726" lastusagedate="20240212T191726">
+              <seg>Estoy bien, gracias.</seg>
+            </tuv>
+          </tu>
+        </body>
+      </tmx>`;
+      const expectedOutput = { "body/tu/1": 'Hello, how are you?', "body/tu/2": "I am fine, thank you." };
+
+      mockFileOperations(input);
+
+      const tmxLoader = createBucketLoader('tmx', 'i18n/Localizable.tmx');
+      tmxLoader.setDefaultLocale('en');
+      const data = await tmxLoader.pull('en');
+
+      expect(data).toEqual(expectedOutput);
+    });
+
+    it('should save tmx', async () => {
+      setupFileMocks();
+      const input = `<?xml version="1.0" encoding="UTF-8"?>
+      <tmx version="1.4">
+        <header
+          creationtool="MyTranslationTool"
+          creationtoolversion="1.0"
+          segtype="sentence"
+          o-tmf="tmx"
+          adminlang="en-US"
+          srclang="en-US"
+          datatype="plaintext"
+        />
+        <body>
+          <tu>
+            <tuv xml:lang="en-US" creationdate="20240212T191726" lastusagedate="20240212T191726">
+              <seg>Hello, how are you?</seg>
+            </tuv>
+          </tu>
+          <tu>
+            <tuv xml:lang="en-US" creationdate="20240212T191726" lastusagedate="20240212T191726">
+              <seg>I am fine, thank you.</seg>
+            </tuv>
+          </tu>
+        </body>
+      </tmx>`;
+
+      const payload = { "body/tu/1": 'Hola, ¿cómo estás?', "body/tu/2" : "Estoy bien, gracias." };
+
+      const expectedOutput = `<?xml version="1.0" encoding="UTF-8"?>
+<tmx version="1.4">
+  <header creationtool="MyTranslationTool" creationtoolversion="1.0" segtype="sentence" o-tmf="tmx" adminlang="en-US" srclang="en-US" datatype="plaintext"/>
+  <body>
+    <tu>
+      <tuv xml:lang="en-US" creationdate="20240212T191726" lastusagedate="20240212T191726">
+        <seg>Hello, how are you?</seg>
+      </tuv>
+      <tuv xml:lang="es-ES" creationdate="20240212T191726" lastusagedate="20240212T191726">
+        <seg>Hola, ¿cómo estás?</seg>
+      </tuv>
+    </tu>
+    <tu>
+      <tuv xml:lang="en-US" creationdate="20240212T191726" lastusagedate="20240212T191726">
+        <seg>I am fine, thank you.</seg>
+      </tuv>
+      <tuv xml:lang="es-ES" creationdate="20240212T191726" lastusagedate="20240212T191726">
+        <seg>Estoy bien, gracias.</seg>
+      </tuv>
+    </tu>
+  </body>
+</tmx>`.trim()+"\n";
+
+      mockFileOperations(input);
+
+      const tmxLoader = createBucketLoader('tmx', 'i18n/Localizable.tmx');
+      tmxLoader.setDefaultLocale('en');
+      await tmxLoader.pull('en');
+
+      await tmxLoader.push('es', payload);
+
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        'i18n/Localizable.tmx',
+        expectedOutput,
+        { encoding: 'utf-8', flag: 'w' },
+      );
+    });
+  });
   
 
 });

--- a/packages/cli/src/loaders/index.ts
+++ b/packages/cli/src/loaders/index.ts
@@ -21,6 +21,7 @@ import createUnlocalizableLoader from './unlocalizable';
 import createPoLoader from './po';
 import createXmlLoader from './xml';
 import createSrtLoader from './srt';
+import createTmxLoader from './tmx';
 
 export default function createBucketLoader(
   bucketType: Z.infer<typeof bucketTypeSchema>,
@@ -121,6 +122,11 @@ export default function createBucketLoader(
     case 'srt': return composeLoaders(
       createTextFileLoader(bucketPathPattern),
       createSrtLoader(),
+      createUnlocalizableLoader(),
+    );
+    case 'tmx': return composeLoaders(
+      createTextFileLoader(bucketPathPattern),
+      createTmxLoader(),
       createUnlocalizableLoader(),
     );
   }

--- a/packages/cli/src/loaders/tmx.ts
+++ b/packages/cli/src/loaders/tmx.ts
@@ -1,0 +1,100 @@
+import { ILoader } from "./_types";
+import { createLoader } from './_utils';
+import { DOMParser, XMLSerializer } from 'xmldom';
+import { Builder, parseStringPromise } from "xml2js";
+
+
+function normalizeLocale(locale: string): string {
+  
+  const localeMapping: Record<string, string> = {
+    ru: "ru",
+    fr: "fr",
+    es: "es-ES",
+    de: "de",
+    "zh-Hans": "zh-Hans",
+    ko: "ko",
+    ja: "ja",
+    it: "it",
+    ar: "ar"
+  };
+  if (!localeMapping[locale]) {
+    console.warn(`Locale "${locale}" is not recognized. Using original value.`);
+  }
+  
+  return localeMapping[locale] || locale;
+}
+
+
+
+export default function createTmxLoader(): ILoader<string, Record<string, any>> {
+  return createLoader({
+    async pull(locale, input) {        
+      const parser = new DOMParser();
+      const xmlDoc = parser.parseFromString(input, 'text/xml');
+      const translationUnits = xmlDoc.getElementsByTagName('tu');
+      const parsedUnits:any = {};
+    
+      for (let i = 0; i < translationUnits.length; i++) {
+        const tu = translationUnits[i];
+        const key = `body/tu/${i + 1}`;
+    
+        const translationElements = tu.getElementsByTagName('tuv');
+        for (let j = 0; j < translationElements.length; j++) {
+          const translationElement = translationElements[j];
+          const langCode = translationElement.getAttribute('xml:lang');
+          const segmentElement = translationElement.getElementsByTagName('seg')[0];
+    
+          if (langCode?.includes(locale) && segmentElement) {
+            parsedUnits[key] = segmentElement.textContent || '';
+            break;
+          }
+        }
+      }
+    
+      return parsedUnits;
+    },
+    async push(locale, payload, originalInput: string) {
+      const parsedXml = await parseStringPromise(originalInput);
+
+  const tuElements = parsedXml?.tmx?.body?.[0]?.tu ?? [];
+
+  Object.entries(payload).forEach(([key, translationText]) => {
+    const [, , tuIndex] = key.split("/");
+    const index = parseInt(tuIndex, 10) - 1;
+    const tuElement = tuElements[index];
+    if (!tuElement) return;
+
+    const existingTuv = tuElement.tuv.find((tuv: any) => tuv.$["xml:lang"] === "en-US");
+    if (!existingTuv || !existingTuv.$) return;
+
+    const creationDate = existingTuv.$.creationdate || "";
+    const lastUsageDate = existingTuv.$.lastusagedate || "";
+
+    const normalizedLocale = normalizeLocale(locale);
+    const newTuv = {
+      $: {
+        "xml:lang": normalizedLocale,
+        creationdate: creationDate,
+        lastusagedate: lastUsageDate,
+      },
+      seg: [translationText],
+    };
+
+    const existingTranslation = tuElement.tuv.find((tuv: any) => tuv.$["xml:lang"] === normalizedLocale);
+    if (existingTranslation) {
+      existingTranslation.seg = [translationText];
+    } else {
+      tuElement.tuv.push(newTuv);
+    }
+  });
+
+  const builder = new Builder({
+    xmldec: { version: "1.0", encoding: "UTF-8" },
+    renderOpts: { pretty: true, indent: "  ", newline: "\n" },
+    headless: false,
+  });
+  
+  return builder.buildObject(parsedXml);
+}
+  });
+}

--- a/packages/spec/src/formats.ts
+++ b/packages/spec/src/formats.ts
@@ -17,6 +17,7 @@ export const bucketTypes = [
   'xml',
   'srt',
   'compiler',
+  'tmx'
 ] as const;
 
 export const bucketTypeSchema = Z.enum(bucketTypes);


### PR DESCRIPTION
Should close #289 

- feat: Implement a new createTmxLoader() function in packages/cli/src/loaders/tmx.ts to handle loading and saving TMX subtitle files
- test: Add two unit tests in packages/cli/src/loaders/index.spec.ts to validate parsing of simple SRT files
- docs: Update @replexica/spec to include the SRT file format specification
- chore: Generate changelogs for both 'replexica' and '@replexica/cli' packages using pnpm new