### PR TITLE
feat: support underscore in locale code

### DIFF
--- a/.changeset/rude-emus-retire.md
+++ b/.changeset/rude-emus-retire.md
@@ -1,0 +1,7 @@
+---
+"@replexica/spec": patch
+"@replexica/cli": patch
+"replexica": patch
+---
+
+support underscore in locale code

--- a/packages/spec/src/config.spec.ts
+++ b/packages/spec/src/config.spec.ts
@@ -24,7 +24,7 @@ const createV1_1Config = () => ({
   version: 1.1,
   locale: {
     source: 'en',
-    targets: ['es', 'fr'],
+    targets: ['es', 'fr', 'pt-PT', 'pt_BR'],
   },
   buckets: {
     json: {

--- a/packages/spec/src/locales.ts
+++ b/packages/spec/src/locales.ts
@@ -186,7 +186,8 @@ export type LocaleCode = LocaleCodeShort | LocaleCodeFull;
 
 export const localeCodesShort = Object.keys(localeMap) as LocaleCodeShort[];
 export const localeCodesFull = Object.values(localeMap).flat() as LocaleCodeFull[];
-export const localeCodes = [...localeCodesShort, ...localeCodesFull] as LocaleCode[];
+export const localeCodesFullUnderscore = localeCodesFull.map(value => value.replace('-', '_'));
+export const localeCodes = [...localeCodesShort, ...localeCodesFull, ...localeCodesFullUnderscore] as LocaleCode[];
 
 export const localeCodeSchema = Z
   .string()


### PR DESCRIPTION
Support [language codes](https://en.wikipedia.org/wiki/IETF_language_tag) with underscore, format used by eg. [Flutter apps](https://docs.flutter.dev/ui/accessibility-and-internationalization/internationalization).